### PR TITLE
don't lock ejs and eco versions

### DIFF
--- a/backbone-on-rails.gemspec
+++ b/backbone-on-rails.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'railties', '>= 3.1'
   s.add_dependency 'jquery-rails'
-  s.add_dependency 'ejs', '~> 1.0.0'
-  s.add_dependency 'eco', '~> 1.0.0'
+  s.add_dependency 'ejs'
+  s.add_dependency 'eco'
 end


### PR DESCRIPTION
Currently backbone-on-rails locks eco and ejs to versions ~> 1.0.0, and as far as I can tell there isn't a reason for this: an eco or ejs API change could break an app using backbone-on-rails, but since backbone-on-rails doesn't directly use either gem (right?), it couldn't break backbone-on-rails itself. We should leave it up to
users to determine which version of eco or ejs they want.

Long story short: ejs 1.0.0 has some significant bugs which were fixed a while ago, but we can't use the newer versions alongside backbone-on-rails unless we unlock the version here.
