### PR TITLE
Make install generator work with Rails Engines

### DIFF
--- a/lib/generators/backbone/helpers.rb
+++ b/lib/generators/backbone/helpers.rb
@@ -75,7 +75,11 @@ module Backbone
       end
 
       def rails_app_name
-        Rails.application.class.name.split('::').first
+        if Rails.application.nil?
+          @destination_stack.first.split("/").last.camelize
+        else
+          Rails.application.class.name.split('::').first
+        end
       end
 
     end


### PR DESCRIPTION
With this fix you are able to run the install generator on Rails Engines. This fixes issue #43
