### PR TITLE
Optional app name and path

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,8 @@ Tricks
     # Use Handlebars File instead of JST
     rails generate backbone:scaffold planet --template=hbs
 
-    # Use SHT instead of JST as JS Object
-    rails generate backbone:scaffold planet --template_controller=SHT
+    # Use SHT instead of JST as template namespace
+    rails generate backbone:scaffold planet --template_namespace=SHT
 
 Alternatives
 ------------

--- a/README.md
+++ b/README.md
@@ -73,9 +73,26 @@ Tricks
     # Generate JavaScript
     rails generate backbone:install --javascript
 
+    # Custom Appname
+    rails generate backbone:install --appname=CustomApp
+
+    # Place code within a sub directory structure
+    rails generate backbone:install --dir=custom_app
+
     # Remove generated files
     rails destroy backbone:scaffold planet
 
+    # Create a custom app name
+    rails generate backbone:scaffold planet -a=CustomApp
+
+    # Generate scaffold in sub directory of assets/javascripts & assets/templates
+    rails generate backbone:scaffold planet -d=custom_app
+
+    # Use Handlebars File instead of JST
+    rails generate backbone:scaffold planet --tpl=hbs
+
+    # Use SHT instead of JST as JS Object
+    rails generate backbone:scaffold planet --tpl_controller=SHT
 
 Alternatives
 ------------

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Tricks
     rails generate backbone:install --javascript
 
     # Custom Appname
-    rails generate backbone:install --appname=CustomApp
+    rails generate backbone:install --app=CustomApp
 
     # Place code within a sub directory structure
     rails generate backbone:install --dir=custom_app
@@ -89,10 +89,10 @@ Tricks
     rails generate backbone:scaffold planet -d=custom_app
 
     # Use Handlebars File instead of JST
-    rails generate backbone:scaffold planet --tpl=hbs
+    rails generate backbone:scaffold planet --template=hbs
 
     # Use SHT instead of JST as JS Object
-    rails generate backbone:scaffold planet --tpl_controller=SHT
+    rails generate backbone:scaffold planet --template_controller=SHT
 
 Alternatives
 ------------

--- a/lib/generators/backbone/helpers.rb
+++ b/lib/generators/backbone/helpers.rb
@@ -75,7 +75,7 @@ module Backbone
       end
 
       def rails_app_name
-        Rails.application.class.name.split('::').first
+        @rails_app_name ||= Rails.application.class.name.split('::').first
       end
 
     end

--- a/lib/generators/backbone/helpers.rb
+++ b/lib/generators/backbone/helpers.rb
@@ -7,7 +7,7 @@ module Backbone
       end
 
       def javascript_path
-        File.join(asset_path, 'javascripts')
+        File.join(asset_path, ['javascripts', @subdirname].compact.join('/'))
       end
 
       def model_path
@@ -27,7 +27,7 @@ module Backbone
       end
 
       def template_path
-        File.join(asset_path, "templates")
+        File.join(asset_path, ['templates', @subdirname].compact.join('/'))
       end
 
       def singular_file_name
@@ -63,7 +63,7 @@ module Backbone
       end
 
       def template_namespace
-        File.join(file_path.pluralize, "index")
+        File.join([@subdirname, file_path.pluralize].compact.join('/'), "index")
       end
 
       def app_name

--- a/lib/generators/backbone/helpers.rb
+++ b/lib/generators/backbone/helpers.rb
@@ -66,6 +66,10 @@ module Backbone
         File.join([@subdirname, file_path.pluralize].compact.join('/'), "index")
       end
 
+      def template_controller
+        @template_controller ||= 'JST'
+      end
+
       def app_name
         rails_app_name.camelize
       end

--- a/lib/generators/backbone/install/install_generator.rb
+++ b/lib/generators/backbone/install/install_generator.rb
@@ -21,6 +21,9 @@ module Backbone
                     default: "application.js",
                     desc: "Javascript manifest file to modify (or create)"
 
+      def setup
+        @rails_app_name = options.appname || Rails.application.class.name.split('::').first
+      end
 
       def create_dir_layout
         empty_directory model_path

--- a/lib/generators/backbone/install/install_generator.rb
+++ b/lib/generators/backbone/install/install_generator.rb
@@ -21,6 +21,7 @@ module Backbone
                     default: "application.js",
                     desc: "Javascript manifest file to modify (or create)"
 
+
       def create_dir_layout
         empty_directory model_path
         empty_directory collection_path
@@ -55,7 +56,6 @@ module Backbone
           end
         end
       end
-
     end
   end
 end

--- a/lib/generators/backbone/install/install_generator.rb
+++ b/lib/generators/backbone/install/install_generator.rb
@@ -21,8 +21,21 @@ module Backbone
                     default: "application.js",
                     desc: "Javascript manifest file to modify (or create)"
 
+      class_option :appname,
+                    type: :string,
+                    aliases: "-a",
+                    default: nil,
+                    desc: "Application Name"
+
+      class_option :dir,
+                    type: :string,
+                    aliases: "-d",
+                    default: nil,
+                    desc: "Subdirectory for files"
+
       def setup
-        @rails_app_name = options.appname || Rails.application.class.name.split('::').first
+        @rails_app_name = options.appname
+        @subdirname = options.dir
       end
 
       def create_dir_layout

--- a/lib/generators/backbone/install/install_generator.rb
+++ b/lib/generators/backbone/install/install_generator.rb
@@ -21,7 +21,7 @@ module Backbone
                     default: "application.js",
                     desc: "Javascript manifest file to modify (or create)"
 
-      class_option :appname,
+      class_option :app,
                     type: :string,
                     aliases: "-a",
                     default: nil,
@@ -34,7 +34,7 @@ module Backbone
                     desc: "Subdirectory for files"
 
       def setup
-        @rails_app_name = options.appname
+        @rails_app_name = options.app
         @subdirname = options.dir
       end
 

--- a/lib/generators/backbone/scaffold/scaffold_generator.rb
+++ b/lib/generators/backbone/scaffold/scaffold_generator.rb
@@ -31,7 +31,7 @@ module Backbone
         js = options.javascript
         @ext = js ? ".js" : ".js.coffee"
         @jst = js ? ".ejs" : ".eco"
-        @rails_app_name = options.appname || Rails.application.class.name.split('::').first
+        @rails_app_name = options.appname
         @subdirname = options.dir
       end
 

--- a/lib/generators/backbone/scaffold/scaffold_generator.rb
+++ b/lib/generators/backbone/scaffold/scaffold_generator.rb
@@ -27,12 +27,38 @@ module Backbone
                     default: nil,
                     desc: "Subdirectory for files"
 
+      class_option :tpl,
+                    type: :string,
+                    default: "ejs",
+                    desc: "Extension for template files"
+
+      class_option :tpl_controller,
+                    type: :string,
+                    default: "JST",
+                    desc: "Template controller (ex: JST / SHT / and so on)"
+
       def parse_options
         js = options.javascript
         @ext = js ? ".js" : ".js.coffee"
-        @jst = js ? ".ejs" : ".eco"
         @rails_app_name = options.appname
         @subdirname = options.dir
+      end
+
+      def parse_javascript_templates
+        js = options.javascript
+
+        # Add additional formats here if we'd like to extend.
+        # => 2015/05/26 Added Handlebars Templates.
+        #
+        @jst = case options.tpl
+          when 'hbs'
+            'hbs'
+          else
+            js ? 'jst.ejs' : 'jst.eco'
+        end
+
+        # Instead of re-writing the template portion of the JS repeatedly, adding an option to allow custom object name for templates
+        @template_controller = options.tpl_controller
       end
 
       def create_backbone_model
@@ -58,8 +84,8 @@ module Backbone
 
       def create_backbone_template
         empty_directory File.join(template_path, file_name.pluralize)
-        file = File.join(template_path, file_name.pluralize, "index.jst#{@jst}")
-        template "template.jst#{@jst}", file
+        file = File.join(template_path, file_name.pluralize, "index.#{@jst}")
+        template "template.#{@jst}", file
       end
 
     end

--- a/lib/generators/backbone/scaffold/scaffold_generator.rb
+++ b/lib/generators/backbone/scaffold/scaffold_generator.rb
@@ -15,7 +15,7 @@ module Backbone
                     default: false,
                     desc: "Generate JavaScript"
 
-      class_option :appname,
+      class_option :app,
                     type: :string,
                     aliases: "-a",
                     default: nil,
@@ -27,20 +27,20 @@ module Backbone
                     default: nil,
                     desc: "Subdirectory for files"
 
-      class_option :tpl,
+      class_option :template,
                     type: :string,
                     default: "ejs",
                     desc: "Extension for template files"
 
-      class_option :tpl_controller,
+      class_option :template_namespace,
                     type: :string,
                     default: "JST",
-                    desc: "Template controller (ex: JST / SHT / and so on)"
+                    desc: "Template namespace (ex: JST / SHT / and so on)"
 
       def parse_options
         js = options.javascript
         @ext = js ? ".js" : ".js.coffee"
-        @rails_app_name = options.appname
+        @rails_app_name = options.app
         @subdirname = options.dir
       end
 
@@ -50,7 +50,7 @@ module Backbone
         # Add additional formats here if we'd like to extend.
         # => 2015/05/26 Added Handlebars Templates.
         #
-        @jst = case options.tpl
+        @jst = case options.template
           when 'hbs'
             'hbs'
           else
@@ -58,7 +58,7 @@ module Backbone
         end
 
         # Instead of re-writing the template portion of the JS repeatedly, adding an option to allow custom object name for templates
-        @template_controller = options.tpl_controller
+        @template_controller = options.template_namespace
       end
 
       def create_backbone_model

--- a/lib/generators/backbone/scaffold/scaffold_generator.rb
+++ b/lib/generators/backbone/scaffold/scaffold_generator.rb
@@ -21,11 +21,18 @@ module Backbone
                     default: nil,
                     desc: "Application Name"
 
+      class_option :dir,
+                    type: :string,
+                    aliases: "-d",
+                    default: nil,
+                    desc: "Subdirectory for files"
+
       def parse_options
         js = options.javascript
         @ext = js ? ".js" : ".js.coffee"
         @jst = js ? ".ejs" : ".eco"
         @rails_app_name = options.appname || Rails.application.class.name.split('::').first
+        @subdirname = options.dir
       end
 
       def create_backbone_model

--- a/lib/generators/backbone/scaffold/scaffold_generator.rb
+++ b/lib/generators/backbone/scaffold/scaffold_generator.rb
@@ -15,10 +15,17 @@ module Backbone
                     default: false,
                     desc: "Generate JavaScript"
 
+      class_option :appname,
+                    type: :string,
+                    aliases: "-a",
+                    default: nil,
+                    desc: "Application Name"
+
       def parse_options
         js = options.javascript
         @ext = js ? ".js" : ".js.coffee"
         @jst = js ? ".ejs" : ".eco"
+        @rails_app_name = options.appname || Rails.application.class.name.split('::').first
       end
 
       def create_backbone_model

--- a/lib/generators/backbone/scaffold/templates/view.js
+++ b/lib/generators/backbone/scaffold/templates/view.js
@@ -1,5 +1,5 @@
 <%= view_namespace %> = Backbone.View.extend({
 
-  template: JST['<%= template_namespace %>']
+  template: <%= template_controller %>['<%= template_namespace %>']
 
 });

--- a/lib/generators/backbone/scaffold/templates/view.js.coffee
+++ b/lib/generators/backbone/scaffold/templates/view.js.coffee
@@ -1,3 +1,3 @@
 class <%= view_namespace %> extends Backbone.View
 
-  template: JST['<%= template_namespace %>']
+  template: <%= template_controller %>['<%= template_namespace %>']

--- a/test/generators/install_generator_test.rb
+++ b/test/generators/install_generator_test.rb
@@ -24,6 +24,15 @@ class InstallGeneratorTest < Rails::Generators::TestCase
     assert_directory template_path
   end
 
+  test "directory structure is created in a subdirectory" do
+    run_generator ['-d=custom']
+    assert_directory 'app/assets/javascripts/custom/routers'
+    assert_directory 'app/assets/javascripts/custom/models'
+    assert_directory 'app/assets/javascripts/custom/collections'
+    assert_directory 'app/assets/javascripts/custom/views'
+    assert_directory 'app/assets/templates/custom'
+  end
+
   test "app coffee file is created" do
     run_generator
     assert_file "#{javascript_path}/#{app_filename}.js.coffee" do |content|
@@ -34,13 +43,9 @@ class InstallGeneratorTest < Rails::Generators::TestCase
 
   test "app coffee file is created with custom app name" do
     run_generator ['-a=Custom']
-
-    assert_equal(app_filename, 'custom')
-    assert_equal(app_name, 'Custom')
-
-    assert_file "#{javascript_path}/#{app_filename}.js.coffee" do |content|
-      assert_match(/window\.#{app_name}/, content)
-      assert_match(/#{app_name}\.initialize/, content)
+    assert_file "#{javascript_path}/custom.js.coffee" do |content|
+      assert_match(/window\.Custom/, content)
+      assert_match(/Custom\.initialize/, content)
     end
   end
 

--- a/test/generators/install_generator_test.rb
+++ b/test/generators/install_generator_test.rb
@@ -34,9 +34,11 @@ class InstallGeneratorTest < Rails::Generators::TestCase
 
   test "app coffee file is created with custom app name" do
     run_generator ['-a=Custom']
+
+    assert_equal(app_filename, 'custom')
+    assert_equal(app_name, 'Custom')
+
     assert_file "#{javascript_path}/#{app_filename}.js.coffee" do |content|
-      asset_equal(app_filename, 'custom.js.coffeee')
-      asset_equal(app_name, 'Custom')
       assert_match(/window\.#{app_name}/, content)
       assert_match(/#{app_name}\.initialize/, content)
     end

--- a/test/generators/install_generator_test.rb
+++ b/test/generators/install_generator_test.rb
@@ -32,6 +32,16 @@ class InstallGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  test "app coffee file is created with custom app name" do
+    run_generator ['-a=Custom']
+    assert_file "#{javascript_path}/#{app_filename}.js.coffee" do |content|
+      asset_equal(app_filename, 'custom.js.coffeee')
+      asset_equal(app_name, 'Custom')
+      assert_match(/window\.#{app_name}/, content)
+      assert_match(/#{app_name}\.initialize/, content)
+    end
+  end
+
   test "app javascript file is created" do
     run_generator ['--javascript']
     assert_file "#{javascript_path}/#{app_filename}.js" do |content|

--- a/test/generators/scaffold_generator_test.rb
+++ b/test/generators/scaffold_generator_test.rb
@@ -22,6 +22,13 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  test "model coffee file is created with custom Appname" do
+    run_generator ['planet', '-a=Custom']
+    assert_file "#{model_path}/planet.js.coffee" do |content|
+      assert_match('class Custom.Models.Planet', content)
+    end
+  end
+
   test "model javascript file is created" do
     run_generator ['planet', '--javascript']
     assert_file "#{model_path}/planet.js" do |content|
@@ -34,6 +41,14 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
     assert_file "#{collection_path}/planets.js.coffee" do |content|
       assert_match('class Dummy.Collections.Planets', content)
       assert_match('model: Dummy.Models.Planet', content)
+    end
+  end
+
+  test "collection coffee file is created with custom App" do
+    run_generator ['planet', '-a=Custom']
+    assert_file "#{collection_path}/planets.js.coffee" do |content|
+      assert_match('class Custom.Collections.Planets', content)
+      assert_match('model: Custom.Models.Planet', content)
     end
   end
 
@@ -59,6 +74,13 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  test "router coffee file is created with custom appname" do
+    run_generator ['planet', '-a=Custom']
+    assert_file "#{router_path}/planets_router.js.coffee" do |content|
+      assert_match('class Custom.Routers.Planets', content)
+    end
+  end
+
   test "view coffee file is created" do
     run_generator ['planet']
     assert_file "#{view_path}/planets/planets_index.js.coffee" do |content|
@@ -71,6 +93,14 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
     run_generator ['planet', '--javascript']
     assert_file "#{view_path}/planets/planets_index.js" do |content|
       assert_match('Dummy.Views.PlanetsIndex = Backbone.View.extend', content)
+      assert_match("template: JST['planets/index']", content)
+    end
+  end
+
+  test "view coffee file is created with custom appname" do
+    run_generator ['planet', '-a=Custom']
+    assert_file "#{view_path}/planets/planets_index.js.coffee" do |content|
+      assert_match('class Custom.Views.PlanetsIndex', content)
       assert_match("template: JST['planets/index']", content)
     end
   end

--- a/test/generators/scaffold_generator_test.rb
+++ b/test/generators/scaffold_generator_test.rb
@@ -29,6 +29,13 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  test "model coffee file is created in a subdir" do
+    run_generator ['planet', '--dir=custom']
+    assert_file "app/assets/javascripts/custom/models/planet.js.coffee" do |content|
+      assert_match('class Dummy.Models.Planet', content)
+    end
+  end
+
   test "model javascript file is created" do
     run_generator ['planet', '--javascript']
     assert_file "#{model_path}/planet.js" do |content|
@@ -47,6 +54,14 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
   test "collection coffee file is created with custom App" do
     run_generator ['planet', '-a=Custom']
     assert_file "#{collection_path}/planets.js.coffee" do |content|
+      assert_match('class Custom.Collections.Planets', content)
+      assert_match('model: Custom.Models.Planet', content)
+    end
+  end
+
+  test "collection coffee file is created in a subdir" do
+    run_generator ['planet', '--dir=custom', '--appname=Custom']
+    assert_file "app/assets/javascripts/custom/collections/planets.js.coffee" do |content|
       assert_match('class Custom.Collections.Planets', content)
       assert_match('model: Custom.Models.Planet', content)
     end
@@ -74,6 +89,13 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  test "router coffee file is created in a subdir" do
+    run_generator ['planet', '--dir=custom']
+    assert_file "app/assets/javascripts/custom/routers/planets_router.js.coffee" do |content|
+      assert_match('class Dummy.Routers.Planets', content)
+    end
+  end
+
   test "router coffee file is created with custom appname" do
     run_generator ['planet', '-a=Custom']
     assert_file "#{router_path}/planets_router.js.coffee" do |content|
@@ -86,6 +108,14 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
     assert_file "#{view_path}/planets/planets_index.js.coffee" do |content|
       assert_match('class Dummy.Views.PlanetsIndex', content)
       assert_match("template: JST['planets/index']", content)
+    end
+  end
+
+  test "view coffee file is created in subdir" do
+    run_generator ['planet', '-d=custom']
+    assert_file "app/assets/javascripts/custom/views/planets/planets_index.js.coffee" do |content|
+      assert_match('class Dummy.Views.PlanetsIndex', content)
+      assert_match("template: JST['custom/planets/index']", content)
     end
   end
 
@@ -108,6 +138,11 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
   test "template eco file is created" do
     run_generator ['planet']
     assert_file "#{template_path}/planets/index.jst.eco"
+  end
+
+  test "template eco file is created in subdir" do
+    run_generator ['planet', '-d=custom']
+    assert_file "app/assets/templates/custom/planets/index.jst.eco"
   end
 
   test "template jst file is created" do

--- a/test/generators/scaffold_generator_test.rb
+++ b/test/generators/scaffold_generator_test.rb
@@ -60,7 +60,7 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
   end
 
   test "collection coffee file is created in a subdir" do
-    run_generator ['planet', '--dir=custom', '--appname=Custom']
+    run_generator ['planet', '--dir=custom', '--app=Custom']
     assert_file "app/assets/javascripts/custom/collections/planets.js.coffee" do |content|
       assert_match('class Custom.Collections.Planets', content)
       assert_match('model: Custom.Models.Planet', content)
@@ -128,7 +128,7 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
   end
 
   test "view coffee file is created with a different template controller" do
-    run_generator ['planet', '--tpl_controller=SHT']
+    run_generator ['planet', '--template_namespace=SHT']
     assert_file "#{view_path}/planets/planets_index.js.coffee" do |content|
       assert_match('class Dummy.Views.PlanetsIndex', content)
       assert_match("template: SHT['planets/index']", content)
@@ -136,7 +136,7 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
   end
 
   test "view javascript file is created with a different template controller" do
-    run_generator ['planet', '--javascript', '--tpl_controller=SHT']
+    run_generator ['planet', '--javascript', '--template_namespace=SHT']
     assert_file "#{view_path}/planets/planets_index.js" do |content|
       assert_match('Dummy.Views.PlanetsIndex = Backbone.View.extend', content)
       assert_match("template: SHT['planets/index']", content)
@@ -152,7 +152,7 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
   end
 
   test "template eco file is created with handlebars" do
-    run_generator ['planet', '--tpl=hbs']
+    run_generator ['planet', '--template=hbs']
     assert_file "#{template_path}/planets/index.hbs"
   end
 

--- a/test/generators/scaffold_generator_test.rb
+++ b/test/generators/scaffold_generator_test.rb
@@ -127,12 +127,33 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  test "view coffee file is created with a different template controller" do
+    run_generator ['planet', '--tpl_controller=SHT']
+    assert_file "#{view_path}/planets/planets_index.js.coffee" do |content|
+      assert_match('class Dummy.Views.PlanetsIndex', content)
+      assert_match("template: SHT['planets/index']", content)
+    end
+  end
+
+  test "view javascript file is created with a different template controller" do
+    run_generator ['planet', '--javascript', '--tpl_controller=SHT']
+    assert_file "#{view_path}/planets/planets_index.js" do |content|
+      assert_match('Dummy.Views.PlanetsIndex = Backbone.View.extend', content)
+      assert_match("template: SHT['planets/index']", content)
+    end
+  end
+
   test "view coffee file is created with custom appname" do
     run_generator ['planet', '-a=Custom']
     assert_file "#{view_path}/planets/planets_index.js.coffee" do |content|
       assert_match('class Custom.Views.PlanetsIndex', content)
       assert_match("template: JST['planets/index']", content)
     end
+  end
+
+  test "template eco file is created with handlebars" do
+    run_generator ['planet', '--tpl=hbs']
+    assert_file "#{template_path}/planets/index.hbs"
   end
 
   test "template eco file is created" do


### PR DESCRIPTION
_Add support for dynamic Backbone application names, sub directories, and .hbs templates._

**Why?**
The naming conventions are excellent and so are the generators, however, it causes a problem when you need multiple Backbone Apps in a single project. This happens when you have a public design and a CMS design

Generator options added:

    # Custom Appname
    rails generate backbone:install --app=CustomApp

    # Place code within a sub directory structure
    rails generate backbone:install --dir=custom_app

    # Create a custom app name
    rails generate backbone:scaffold planet -a=CustomApp

    # Generate scaffold in sub directory of assets/javascripts & assets/templates
    rails generate backbone:scaffold planet -d=custom_app

    # Use Handlebars File instead of JST
    rails generate backbone:scaffold planet --template=hbs

    # Use SHT instead of JST as template namespace
    rails generate backbone:scaffold planet --template_namespace=SHT

_Tests added & passing_

I did not bump versions -- is it possible we can bump version and get this on rubygems.org instead of having a git repo?

(edit: update generator names)